### PR TITLE
Add wearable integration modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# One Doctor Service
+
+This repository contains a Flask backend with sample APIs for health data. The project now includes utilities for reading vital signs from wearable devices.
+
+## Wearable Integrations
+
+New modules under `src/integrations` provide basic clients for different devices. Currently the Fitbit client includes a simple implementation using the public Fitbit API. Apple Watch and Google Fit clients are provided as placeholders for future expansion.
+
+Example usage:
+
+```python
+from src.integrations import FitbitClient
+
+client = FitbitClient(access_token="YOUR_TOKEN")
+heart_data = client.fetch_vitals()
+```
+
+These helpers can be extended to parse additional vitals like heartbeat, pulse and body temperature.

--- a/src/integrations/__init__.py
+++ b/src/integrations/__init__.py
@@ -1,0 +1,13 @@
+"""Wearable device integrations."""
+
+from .fitbit import FitbitClient
+from .apple_watch import AppleWatchClient
+from .google_fit import GoogleFitClient
+from .base import WearableClient
+
+__all__ = [
+    "WearableClient",
+    "FitbitClient",
+    "AppleWatchClient",
+    "GoogleFitClient",
+]

--- a/src/integrations/apple_watch.py
+++ b/src/integrations/apple_watch.py
@@ -1,0 +1,13 @@
+"""Placeholder integration for Apple Watch / iPhone Health data."""
+from .base import WearableClient
+
+
+class AppleWatchClient(WearableClient):
+    """Client for fetching data from Apple HealthKit (not implemented)."""
+
+    def __init__(self, auth_token: str):
+        self.auth_token = auth_token
+
+    def fetch_vitals(self) -> dict:
+        """Fetch health data from Apple HealthKit. Raises NotImplementedError."""
+        raise NotImplementedError("Apple HealthKit integration not implemented")

--- a/src/integrations/base.py
+++ b/src/integrations/base.py
@@ -1,0 +1,6 @@
+class WearableClient:
+    """Base class for wearable device integrations."""
+
+    def fetch_vitals(self):
+        """Return a dictionary of vital signs."""
+        raise NotImplementedError

--- a/src/integrations/fitbit.py
+++ b/src/integrations/fitbit.py
@@ -1,0 +1,20 @@
+"""Integration utilities for Fitbit devices."""
+import requests
+from .base import WearableClient
+
+
+class FitbitClient(WearableClient):
+    """Client for accessing Fitbit health data."""
+
+    API_URL = "https://api.fitbit.com"
+
+    def __init__(self, access_token: str):
+        self.access_token = access_token
+
+    def fetch_vitals(self) -> dict:
+        """Fetch heart rate and other vitals from Fitbit API."""
+        headers = {"Authorization": f"Bearer {self.access_token}"}
+        url = f"{self.API_URL}/1/user/-/activities/heart/date/today/1d.json"
+        response = requests.get(url, headers=headers, timeout=10)
+        response.raise_for_status()
+        return response.json()

--- a/src/integrations/google_fit.py
+++ b/src/integrations/google_fit.py
@@ -1,0 +1,13 @@
+"""Placeholder integration for Google Fit / Android health data."""
+from .base import WearableClient
+
+
+class GoogleFitClient(WearableClient):
+    """Client for fetching data from Google Fit (not implemented)."""
+
+    def __init__(self, auth_token: str):
+        self.auth_token = auth_token
+
+    def fetch_vitals(self) -> dict:
+        """Fetch health data from Google Fit. Raises NotImplementedError."""
+        raise NotImplementedError("Google Fit integration not implemented")

--- a/tests/test_wearables.py
+++ b/tests/test_wearables.py
@@ -1,0 +1,23 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from src.integrations.fitbit import FitbitClient
+
+
+class FitbitClientTestCase(unittest.TestCase):
+    @patch('src.integrations.fitbit.requests.get')
+    def test_fetch_vitals(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {'activities-heart': []}
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        client = FitbitClient('dummy-token')
+        data = client.fetch_vitals()
+
+        self.assertEqual(data, {'activities-heart': []})
+        mock_get.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add integrations package for wearables
- implement Fitbit client and placeholder clients for Apple Watch and Google Fit
- provide new tests for Fitbit integration
- document wearables integration in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68866fa870cc832d9617061a53076f43