### PR TITLE
Prepare backend for Render deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn "app:create_app()"
+web: gunicorn -b 0.0.0.0:$PORT "app:create_app()"

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,6 @@
+services:
+  - type: web
+    name: one-doctor-service
+    env: python
+    buildCommand: pip install -r requirements.txt
+    startCommand: gunicorn -b 0.0.0.0:$PORT app:create_app()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-flask 
-flask-cors 
-firebase-admin 
+flask
+flask-cors
+firebase-admin
 requests
-dotenv
+python-dotenv
 gunicorn
 flask-jwt-extended


### PR DESCRIPTION
## Summary
- improve requirements with correct dotenv dependency
- bind gunicorn to render-provided port
- add Render config file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688681e7d46c832d91818e37420c5f7a